### PR TITLE
sdm845-common: Keep fpc in system-background

### DIFF
--- a/fingerprint/android.hardware.biometrics.fingerprint@2.1-service.xiaomi_sdm845.rc
+++ b/fingerprint/android.hardware.biometrics.fingerprint@2.1-service.xiaomi_sdm845.rc
@@ -48,6 +48,7 @@ service vendor.fps_hal /vendor/bin/hw/android.hardware.biometrics.fingerprint@2.
     class late_start
     user system
     group system input
+    writepid /dev/cpuset/system-background/tasks
 
 on property:vendor.fps_hal.restartimes=max
     stop vendor.fps_hal


### PR DESCRIPTION
The fingerprint HAL is insensitive to increased CPU throughput, but it also
has a tendency to spin while waiting for FP hardware. Limit FPC to the
system-background cpuset in order to avoid increased power consumption
when accidentally touching the fingerprint sensor.

bug 76115243
Test: fingerprint in system-background cpuset on taimen

Change-Id: Iaffe6f63bd76b7a1c4acaf0cae980840af515961